### PR TITLE
Rx 라이브러리 의존성 추가

### DIFF
--- a/DevNote/DevNote.xcodeproj/project.pbxproj
+++ b/DevNote/DevNote.xcodeproj/project.pbxproj
@@ -6,6 +6,14 @@
 	objectVersion = 77;
 	objects = {
 
+/* Begin PBXBuildFile section */
+		AF656C672D19AAA200F523EC /* RxBlocking in Frameworks */ = {isa = PBXBuildFile; productRef = AF656C662D19AAA200F523EC /* RxBlocking */; };
+		AF656C692D19AAA200F523EC /* RxCocoa in Frameworks */ = {isa = PBXBuildFile; productRef = AF656C682D19AAA200F523EC /* RxCocoa */; };
+		AF656C6B2D19AAA200F523EC /* RxRelay in Frameworks */ = {isa = PBXBuildFile; productRef = AF656C6A2D19AAA200F523EC /* RxRelay */; };
+		AF656C6D2D19AAA200F523EC /* RxSwift in Frameworks */ = {isa = PBXBuildFile; productRef = AF656C6C2D19AAA200F523EC /* RxSwift */; };
+		AF656C6F2D19AAA200F523EC /* RxTest in Frameworks */ = {isa = PBXBuildFile; productRef = AF656C6E2D19AAA200F523EC /* RxTest */; };
+/* End PBXBuildFile section */
+
 /* Begin PBXContainerItemProxy section */
 		AF656B5B2D13E1D500F523EC /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -65,6 +73,9 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				AF656C6D2D19AAA200F523EC /* RxSwift in Frameworks */,
+				AF656C6B2D19AAA200F523EC /* RxRelay in Frameworks */,
+				AF656C692D19AAA200F523EC /* RxCocoa in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -72,6 +83,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				AF656C6F2D19AAA200F523EC /* RxTest in Frameworks */,
+				AF656C672D19AAA200F523EC /* RxBlocking in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -125,6 +138,9 @@
 			);
 			name = DevNote;
 			packageProductDependencies = (
+				AF656C682D19AAA200F523EC /* RxCocoa */,
+				AF656C6A2D19AAA200F523EC /* RxRelay */,
+				AF656C6C2D19AAA200F523EC /* RxSwift */,
 			);
 			productName = DevNote;
 			productReference = AF656B442D13E1D300F523EC /* DevNote.app */;
@@ -148,6 +164,8 @@
 			);
 			name = DevNoteTests;
 			packageProductDependencies = (
+				AF656C662D19AAA200F523EC /* RxBlocking */,
+				AF656C6E2D19AAA200F523EC /* RxTest */,
 			);
 			productName = DevNoteTests;
 			productReference = AF656B5A2D13E1D500F523EC /* DevNoteTests.xctest */;
@@ -208,6 +226,9 @@
 			);
 			mainGroup = AF656B3B2D13E1D300F523EC;
 			minimizedProjectReferenceProxies = 1;
+			packageReferences = (
+				AF656C652D19AAA200F523EC /* XCRemoteSwiftPackageReference "RxSwift" */,
+			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = AF656B452D13E1D300F523EC /* Products */;
 			projectDirPath = "";
@@ -579,6 +600,45 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		AF656C652D19AAA200F523EC /* XCRemoteSwiftPackageReference "RxSwift" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/ReactiveX/RxSwift.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 6.8.0;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		AF656C662D19AAA200F523EC /* RxBlocking */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = AF656C652D19AAA200F523EC /* XCRemoteSwiftPackageReference "RxSwift" */;
+			productName = RxBlocking;
+		};
+		AF656C682D19AAA200F523EC /* RxCocoa */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = AF656C652D19AAA200F523EC /* XCRemoteSwiftPackageReference "RxSwift" */;
+			productName = RxCocoa;
+		};
+		AF656C6A2D19AAA200F523EC /* RxRelay */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = AF656C652D19AAA200F523EC /* XCRemoteSwiftPackageReference "RxSwift" */;
+			productName = RxRelay;
+		};
+		AF656C6C2D19AAA200F523EC /* RxSwift */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = AF656C652D19AAA200F523EC /* XCRemoteSwiftPackageReference "RxSwift" */;
+			productName = RxSwift;
+		};
+		AF656C6E2D19AAA200F523EC /* RxTest */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = AF656C652D19AAA200F523EC /* XCRemoteSwiftPackageReference "RxSwift" */;
+			productName = RxTest;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = AF656B3C2D13E1D300F523EC /* Project object */;
 }

--- a/DevNote/DevNote.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DevNote/DevNote.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,15 @@
+{
+  "originHash" : "87bc79fcccc55ce355a01b2e68fcd580a18765a117cbee40f0c77cddde507f26",
+  "pins" : [
+    {
+      "identity" : "rxswift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ReactiveX/RxSwift.git",
+      "state" : {
+        "revision" : "c7c7d2cf50a3211fe2843f76869c698e4e417930",
+        "version" : "6.8.0"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/DevNote/DevNote/RxTextViewController.swift
+++ b/DevNote/DevNote/RxTextViewController.swift
@@ -1,0 +1,65 @@
+//
+//  RxTextViewController.swift
+//  DevNote
+//
+//  Created by 이종선 on 12/23/24.
+//
+
+import UIKit
+import RxSwift
+import RxCocoa
+
+class RxTextViewController: UIViewController {
+    
+    private let disposeBag = DisposeBag()
+    private let testLabel = UILabel()
+    private let testButton = UIButton()
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        view.backgroundColor = .white
+        setupUI()
+        
+        // RxSwift
+        /// Observable 생성 및 구독
+        Observable.just("Hello RxSwift")
+            .subscribe(onNext: { text in
+                print(text)
+            }
+            )
+            .disposed(by: disposeBag)
+        
+        // RxCocoa
+        /// button 클릭 이벤트를 Observable로 반환
+        /// 즉 버튼 이벤트를 구독한후 해당 이벤트 발생시 실행할 동작 정의
+        testButton.rx.tap
+            .subscribe(onNext: { [weak self] in
+                self?.testLabel.text = "RxSwift 작동 확인 "
+            })
+            .disposed(by: disposeBag)
+    }
+    
+    private func setupUI() {
+        // 레이블 설정
+        testLabel.text = "테스트 레이블"
+        testLabel.textAlignment = .center
+        testLabel.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(testLabel)
+        
+        // 버튼 설정
+        testButton.setTitle("테스트 버튼", for: .normal)
+        testButton.setTitleColor(.blue, for: .normal)
+        testButton.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(testButton)
+        
+        // 오토레이아웃 설정
+        NSLayoutConstraint.activate([
+            testLabel.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            testLabel.centerYAnchor.constraint(equalTo: view.centerYAnchor),
+            
+            testButton.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            testButton.topAnchor.constraint(equalTo: testLabel.bottomAnchor, constant: 20)
+        ])
+    }
+}

--- a/DevNote/DevNote/SceneDelegate.swift
+++ b/DevNote/DevNote/SceneDelegate.swift
@@ -16,8 +16,8 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         guard let windowScene = (scene as? UIWindowScene) else { return }
         
         let window = UIWindow(windowScene: windowScene)
+        window.rootViewController = RxTextViewController()
         window.makeKeyAndVisible()
-        window.rootViewController = ViewController()
         self.window = window
     }
 

--- a/DevNote/DevNoteTests/RxSwiftTests.swift
+++ b/DevNote/DevNoteTests/RxSwiftTests.swift
@@ -1,0 +1,22 @@
+//
+//  RxSwiftTests.swift
+//  DevNote
+//
+//  Created by 이종선 on 12/24/24.
+//
+
+import XCTest
+import RxSwift
+import RxBlocking
+import RxTest
+
+class RxSwiftTests: XCTestCase {
+    func testRxSwiftInstallation() throws {
+        // 단일 값 방출
+        let observable = Observable.just("Test")
+        // 해당 observable 객체가 첫번째 값을 방출할 때까지 현재 쓰레드 block
+        let result = try observable.toBlocking().first()
+        XCTAssertEqual(result, "Test")
+        
+    }
+}


### PR DESCRIPTION
## 🔴 변경 사항 (What)
- RxSwift 프레임워크와 관련 패키지들을 프로젝트에 추가했습니다:
  - RxSwift: 반응형 프로그래밍의 핵심 기능을 제공하는 메인 프레임워크
  - RxCocoa: UIKit과의 통합을 위한 바인딩 및 확장 기능
  - RxRelay: 상태 관리를 위한 Subject 타입들을 제공
  - RxBlocking 및 RxTest: 단위 테스트를 위한 테스트 유틸리티

## 🟠 변경 이유 (Why)
- 반응형 프로그래밍 패러다임을 도입하여 앱의 상태 관리와 데이터 흐름을 더 효과적으로 처리하기 위함입니다
- MVVM 아키텍처 패턴을 더 효과적으로 구현하고, UI와 비즈니스 로직 간의 바인딩을 선언적으로 관리하기 위함입니다
- 비동기 작업과 이벤트 스트림을 더 깔끔하게 처리하기 위한 기반을 마련합니다

## 🟢 추가 노트 (Additional Notes)
- RxSwift 버전은 6.8.0으로 고정되어 있습니다 (upToNextMajorVersion 조건)
- 프로덕션 앱 타겟에는 RxSwift, RxCocoa, RxRelay만 포함되어 있습니다
- 테스트 타겟에는 RxBlocking과 RxTest가 별도로 포함되어 있어 테스트 코드 작성에 활용할 수 있습니다
- 해당 변경은 기존 코드에 영향을 주지 않으며, 점진적으로 RxSwift를 도입할 수 있는 기반을 마련한 것입니다